### PR TITLE
Add info on ShortCut keys being remapped on macOS

### DIFF
--- a/src/OEBPS/Text/preferences.xhtml
+++ b/src/OEBPS/Text/preferences.xhtml
@@ -215,6 +215,12 @@
 			<p class="tiptext">Use the Filter text box to easily search for shortcuts.</p>
 		  </div>
 
+  <div class="tip">
+	<p class="tiptext"><b>Note to Mac users:</b> References to the <span class="shortcut">Ctrl</span> key in Sigil correspond to the <span class="shortcut">Cmd</span> key on the Macintosh keyboard, and references to the <span class="shortcut">Meta</span> key correspond to the <span class="shortcut">Ctrl</span> key on Mac.</p> 
+
+	<p class="tiptext">This is due to Qt’s automatic remapping, which allows each platform’s most common shortcut key sequences to work as expected. For example, when Windows/Linux users press <span class="shortcut">Ctrl+C</span>, they get the Copy command, as they expect; and thanks to Qt’s automatic remapping of <span class="shortcut">Ctrl</span> to <span class="shortcut">Cmd</span> on macOS, when Mac users press <span class="shortcut">Cmd+C</span>, they get the Copy command, as they expect.</p>
+  </div>
+
   <h3 class="sigil_not_in_toc" id="preferences_language">Language</h3>
 
 		  <p>Sigil has been translated into many languages.</p>


### PR DESCRIPTION
As discussed in Issue #2.

Note: I added this info to the Preferences chapter instead of User Interface chapter, since "Ctrl" and "Meta" are used in Preference pane when assigning shortcut keys, so explanation seems useful here. However, when actually using Sigil, shortcuts are shown using keyboard symbols, not words "Ctrl" or "Meta", so this info didn't seem necessary in the User Interface chapter. 