### PR TITLE
Wrap edit

### DIFF
--- a/src/OEBPS/Text/find_replace.xhtml
+++ b/src/OEBPS/Text/find_replace.xhtml
@@ -223,27 +223,27 @@
 
   		<li><p><span class="listheading">All HTML Files:</span> Search in every HTML/XHTML file – but do not search in other file types, such as CSS, OPF or NCX.</p>
 
-  			<p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous file (in the order listed in the Book Browser). If Wrap is turned on, it will loop around until all files have been searched.</p></li>
+  			<p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous file (in the order listed in the Book Browser). <b>Wrap</b> does not apply when searching multiple files.</p></li>
 
   		<li><p><span class="listheading">Selected HTML Files:</span> Search only the HTML files selected in the Book Browser.</p>
 
-  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order listed in the Book Browser). If Wrap is turned on, it will loop around until all selected files have been searched.</p></li>
+  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order listed in the Book Browser). <b>Wrap</b> does not apply when searching multiple files.</p></li>
   		
         <li><p><span class="listheading">Tabbed HTML Files:</span> Search only the HTML files that are open as Tabs in the Tab Manager.</p>
 
-  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order opened in the Tab Manager). If Wrap is turned on, it will loop around until all selected files have been searched.</p></li>
+  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order opened in the Tab Manager). <b>Wrap</b> does not apply when searching multiple files.</p></li>
 
    		<li><p><span class="listheading">All CSS Files:</span> Search in every CSS file – but do not search in other file types, such as HTML, OPF or NCX.</p>
 
-  			<p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous file (in the order listed in the Book Browser). If Wrap is turned on, it will loop around until all files have been searched.</p></li>
+  			<p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous file (in the order listed in the Book Browser). <b>Wrap</b> does not apply when searching multiple files.</p></li>
 
   		<li><p><span class="listheading">Selected CSS Files:</span> Search only the CSS files selected in the Book Browser.</p>
 
-  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order listed in the Book Browser). If Wrap is turned on, it will loop around until all selected files have been searched.</p></li>
+  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order listed in the Book Browser). <b>Wrap</b> does not apply when searching multiple files.</p></li>
   		
         <li><p><span class="listheading">Tabbed CSS Files:</span> Search only the CSS files that are open as Tabs in the Tab Manager.</p>
 
-  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order opened in the Tab Manager). If Wrap is turned on, it will loop around until all selected files have been searched.</p></li>
+  			  <p>When a search reaches the end or beginning of a file, it will automatically move to the next or previous selected file (in the order opened in the Tab Manager). <b>Wrap</b> does not apply when searching multiple files.</p></li>
  			
   		<li><p><span class="listheading">OPF File:</span> Search only the OPF file.</p>
   			  <p>Special care must be used when using Replace in the OPF file as it is effectively the heart of the epub and controls pretty much everything. The importance of Checkpoints or saving the file first can not be overstated.</p></li>


### PR DESCRIPTION
Modification to find_replace.xhtml to remove 6 incorrect wrap statements in the Where to Search section. Replaced with a statement that wrap does not work in multi-file searches.