### PR TITLE
Update manage_plugins.xhtml

### DIFF
--- a/src/OEBPS/Text/manage_plugins.xhtml
+++ b/src/OEBPS/Text/manage_plugins.xhtml
@@ -75,7 +75,7 @@
   </ol>
 
   <div class="tip">
-    <p class="tiptext">Don’t unpack or rename plugin .zip files!</p>
+    <p class="tiptext">Don’t unpack or rename plugin .zip files! If the .zip file doesn't have its original name, you'll see an error message when you try to add the plugin. If your browser is set to automatically unzip zip files after downloading, turn off that feature before downloading a plugin.</p>
   </div>
   
   <p>To remove a plugin:</p>


### PR DESCRIPTION
Adding a note about browsers that automatically unzip after downloading. This note would have saved me about an hour of frustration last night; with auto-unzip (such as in Safari/Mac), it's not possible to find out the correct filename, and with the wrong filename, the error message confusingly says that the .zip file isn't a plugin.